### PR TITLE
set sdk_mapzen_api_key to empty string – setting this is now required

### DIFF
--- a/walkabout-style.yaml
+++ b/walkabout-style.yaml
@@ -18,7 +18,7 @@ import:
 global:
     # Sign up for a Mapzen API key to enjoy higher rate limits
     # https://mapzen.com/documentation/overview/#developer-accounts-and-api-keys
-    sdk_mapzen_api_key: mapzen-ZzW4tEy     # set this value to your Mapzen API key
+    sdk_mapzen_api_key: ''     # set this value to your Mapzen API key
 
     #ux/ui
     ux_language: false             # l10n language code, trusting OSM in v0.10 tiles, fixed in v1.0 tiles


### PR DESCRIPTION
Here goes nothing!