### PR TITLE
Remove inapplicable 'base' draw parameter

### DIFF
--- a/layers/bike-interlay.yaml
+++ b/layers/bike-interlay.yaml
@@ -1133,7 +1133,6 @@ global:
                 - bicycle_network: true
         draw:
             highlight:
-                base: lines
                 order: function() { return feature.sort_rank - 100; }
                 color: global.regional_network_highlight
                 width: [[9, 6px], [10, 7px], [11, 8px], [12, 11px], [13, 13px], [15, 18px], [17, 30px], [19, 60px], [20, 96px]]
@@ -1150,7 +1149,6 @@ global:
                 - bicycle_network: true
         draw:
             highlight:
-                base: lines
                 order: function() { return feature.sort_rank - 100; }
                 color: global.regional_network_highlight
                 width: [[9, 6px], [10, 7px], [11, 8px], [12, 11px], [13, 13px], [15, 15px], [17, 24px], [19, 60px], [20, 96px]]
@@ -1167,7 +1165,6 @@ global:
                 - bicycle_network: true
         draw:
             highlight:
-                base: lines
                 order: function() { return feature.sort_rank - 100; }
                 color: global.regional_network_highlight
                 width: [[10, 0px], [11, 7px], [12, 10px], [13, 12px], [15, 15px], [17, 24px], [19, 60px], [20, 96px]]
@@ -1188,7 +1185,6 @@ global:
                 outline:
                     width: [[10, 0px], [11, 0px], [12, 0.5px], [14, 1px], [16, 2px], [17, 2px], [18, 4px]]
             highlight:
-                base: lines
                 order: function() { return feature.sort_rank - 30; }
                 color: global.regional_network_highlight
                 width: [[11, 4px], [12, 5px], [13, 7px], [15, 13px], [17, 18px], [19, 50px], [20, 90px]]
@@ -1205,7 +1201,6 @@ global:
                 - bicycle_network: true
         draw:
             highlight:
-                base: lines
                 order: function() { return feature.sort_rank - 100; }
                 color: global.regional_network_highlight
                 width: [[9, 6px], [12, 11px], [13, 13px], [15, 11px], [17, 20px], [19, 40px], [20, 70px]]
@@ -1222,7 +1217,6 @@ global:
                 - bicycle_network: true
         draw:
             highlight:
-                base: lines
                 order: function() { return feature.sort_rank - 20; }
                 color: global.regional_network_highlight
                 width: [[11, 0px], [12, 5px], [13, 6px], [15, 11px], [17, 18px], [19, 50px], [20, 90px]]
@@ -1239,7 +1233,6 @@ global:
                 - bicycle_network: true
         draw:
             highlight:
-                base: lines
                 order: function() { return feature.sort_rank - 3; }
                 color: global.regional_network_highlight
                 width: [[11, 0px], [12, 5px], [15, 10px], [17, 13px], [19, 30px]]
@@ -1269,7 +1262,6 @@ global:
                 outline:
                     width: [[13, 0px], [14, 1px], [15, 1px], [17, 2px], [18, 3px]]
             highlight:
-                base: lines
                 order: function() { return feature.sort_rank - 3; }
                 color: global.regional_network_highlight
                 width: [[11, 0px], [12, 5px], [15, 10px], [17, 13px], [19, 30px]]


### PR DESCRIPTION
'base' applies to styles, but not draw rules.