### PR TITLE
adjust z0 normal scale

### DIFF
--- a/walkabout-style.yaml
+++ b/walkabout-style.yaml
@@ -575,8 +575,8 @@ styles:
                 color: |
                     // turn terrain exaggeration up/down
                     // fade out spheremap normals with a function
-                    float scale1 = 20./(u_map_position.z) + 1.5;
-                    float m = u_zoom_scale * (u_map_position.z - 0.8) * exp(u_map_position.z * -.29);
+                    float scale1 = 20./(u_map_position.z + 1.0) + 1.5;
+                    float m = u_zoom_scale * (u_map_position.z + 0.4) * exp(u_map_position.z * -.29);
                     m = clamp(m, 0., 1.5);
                     color = applyEnvmap(u_envmap, normal, 1./scale1);
 


### PR DESCRIPTION
Adjusted the normal-scaling function at low zooms – the effect is eased in through z1 and a very small amount at z2.

Using a custom local test in the differ (new style on the left, old in the middle, differing pixels in red on the right):

<img width="702" alt="screen shot 2017-10-25 at 3 55 09 pm" src="https://user-images.githubusercontent.com/459970/32027334-5524d99e-b99d-11e7-96a0-1725472860c2.png">

<img width="703" alt="screen shot 2017-10-25 at 3 54 32 pm" src="https://user-images.githubusercontent.com/459970/32027345-5af90a70-b99d-11e7-80ce-ef72d0b824e4.png">

By z2 the effect is only barely perceptible in the most extreme slopes, like this one in Greenland:

<img width="703" alt="screen shot 2017-10-25 at 3 55 51 pm" src="https://user-images.githubusercontent.com/459970/32027361-7304a3d6-b99d-11e7-99e4-b17e70dd4844.png">

Past that you see the odd slight difference in a pixel here or there up to around z12:

<img width="702" alt="screen shot 2017-10-25 at 4 01 05 pm" src="https://user-images.githubusercontent.com/459970/32027428-dbbb49f2-b99d-11e7-8e00-93a38f8ffa1a.png">

<img width="703" alt="screen shot 2017-10-25 at 4 00 53 pm" src="https://user-images.githubusercontent.com/459970/32027425-d544317e-b99d-11e7-9115-dc19849b9f61.png">